### PR TITLE
make file useable for windows users

### DIFF
--- a/pycrypcli.py
+++ b/pycrypcli.py
@@ -1,7 +1,10 @@
 import getpass
 import os
 import re
-import readline
+try:
+    import readline
+except ImportError:
+    import pyreadline as readline
 import sys
 from typing import List, Optional, Tuple
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 websocket-client>=0.56.0
+pyreadline


### PR DESCRIPTION
"readline" iss for linux only users, so windows  users import "pyreadline"